### PR TITLE
Removes extraneous newlines.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Current Master
 
-- Nothing yet.
+- Removes newlines surrounding markdown blocks. See [#20](https://github.com/ashfurrow/playgroundbook/issues/20).
 
 # 0.2.1
 

--- a/lib/playgroundbook_renderer/page_processor.rb
+++ b/lib/playgroundbook_renderer/page_processor.rb
@@ -1,6 +1,6 @@
 module Playgroundbook
   class PageProcessor
-    def process_page(page_contents)
+    def strip_extraneous_newlines(page_contents)
       # Three cases we need to look for:
       # - Extraneous newlines before /*:
       # - Extraneous newlines after */

--- a/lib/playgroundbook_renderer/page_processor.rb
+++ b/lib/playgroundbook_renderer/page_processor.rb
@@ -5,7 +5,11 @@ module Playgroundbook
       # - Extraneous newlines before /*:
       # - Extraneous newlines after */
       # - Extraneous newlines either before or after //:
-      page_contents.squeeze("\n")
+      page_contents
+        .gsub(/\n+\/\*:/, "\n/*:")
+        .gsub(/\*\/\n+/, "*/\n")
+        .split(/(\/\/:.*$)\n*/).join("\n") # Important to do this before the next line, because it adds newlines before //: comments.
+        .gsub(/\n+\/\/:/, "\n//:")
     end
   end
 end

--- a/lib/playgroundbook_renderer/page_processor.rb
+++ b/lib/playgroundbook_renderer/page_processor.rb
@@ -1,7 +1,11 @@
 module Playgroundbook
   class PageProcessor
     def process_page(page_contents)
-      page_contents
+      # Three cases we need to look for:
+      # - Extraneous newlines before /*:
+      # - Extraneous newlines after */
+      # - Extraneous newlines either before or after //:
+      page_contents.squeeze("\n")
     end
   end
 end

--- a/lib/playgroundbook_renderer/page_processor.rb
+++ b/lib/playgroundbook_renderer/page_processor.rb
@@ -1,0 +1,7 @@
+module Playgroundbook
+  class PageProcessor
+    def process_page(page_contents)
+      page_contents
+    end
+  end
+end

--- a/lib/playgroundbook_renderer/page_writer.rb
+++ b/lib/playgroundbook_renderer/page_writer.rb
@@ -1,9 +1,10 @@
 require 'plist'
+require 'playgroundbook_renderer/page_processor'
 
 module Playgroundbook
   class PageWriter
-
-    def initialize(ui = Cork::Board.new)
+    def initialize(page_processor = PageProcessor.new, ui = Cork::Board.new)
+      @page_processor = page_processor
       @ui = ui
     end
 
@@ -13,7 +14,7 @@ module Playgroundbook
       contents_with_import = "//#-hidden-code\n"
       contents_with_import += imports.map { |i| "import #{i}" }.join("\n") + "\n"
       contents_with_import += "//#-end-hidden-code\n"
-      contents_with_import += page_contents
+      contents_with_import += @page_processor.process_page(page_contents)
 
       Dir.chdir(page_dir_name) do
         File.open(ContentsSwiftFileName, 'w') do |file|

--- a/lib/playgroundbook_renderer/page_writer.rb
+++ b/lib/playgroundbook_renderer/page_writer.rb
@@ -14,7 +14,7 @@ module Playgroundbook
       contents_with_import = "//#-hidden-code\n"
       contents_with_import += imports.map { |i| "import #{i}" }.join("\n") + "\n"
       contents_with_import += "//#-end-hidden-code\n"
-      contents_with_import += @page_processor.process_page(page_contents)
+      contents_with_import += @page_processor.strip_extraneous_newlines(page_contents)
 
       Dir.chdir(page_dir_name) do
         File.open(ContentsSwiftFileName, 'w') do |file|

--- a/spec/playgroundbook_renderer_spec/page_processor_spec.rb
+++ b/spec/playgroundbook_renderer_spec/page_processor_spec.rb
@@ -19,7 +19,7 @@ let a = 6
 */
       EOS
       
-      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+      expect(page_processor.strip_extraneous_newlines(page_contents)).to eq(processed_page_contents)
     end
 
     it 'removes newlines after markdown blocks' do
@@ -37,7 +37,7 @@ let a = 6
 let a = 6
       EOS
       
-      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+      expect(page_processor.strip_extraneous_newlines(page_contents)).to eq(processed_page_contents)
     end
 
     it 'removes newlines surrounding single-line markdown blocks' do
@@ -54,17 +54,33 @@ let a = 6
 let b = a
       EOS
       
-      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+      expect(page_processor.strip_extraneous_newlines(page_contents)).to eq(processed_page_contents)
     end
 
-    it 'does not strip newlines from code.' do
+    it 'does not strip newlines from code' do
       page_contents = <<-EOS
 let a = 6
 
 let b = a
       EOS
 
-      expect(page_processor.process_page(page_contents)).to eq(page_contents)
+      expect(page_processor.strip_extraneous_newlines(page_contents)).to eq(page_contents)
+    end
+
+    it 'it does not strip newlines from the markdown' do
+      page_contents = <<-EOS
+/*:
+
+ # Header
+ 
+ Some markdown. The following lines are purposefull left blank.
+
+
+
+*/
+      EOS
+      
+      expect(page_processor.strip_extraneous_newlines(page_contents)).to eq(page_contents)
     end
   end
 end

--- a/spec/playgroundbook_renderer_spec/page_processor_spec.rb
+++ b/spec/playgroundbook_renderer_spec/page_processor_spec.rb
@@ -1,0 +1,60 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Playgroundbook
+  describe PageProcessor do
+    let(:page_processor) { PageProcessor.new }
+    
+    it 'removes newlines before markdown blocks' do
+      page_contents = <<-EOS
+let a = 6
+
+/*:
+ Some markdown.
+*/
+      EOS
+      processed_page_contents = <<-EOS
+let a = 6
+/*:
+ Some markdown.
+*/
+      EOS
+      
+      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+    end
+
+    it 'removes newlines after markdown blocks' do
+      page_contents = <<-EOS
+/*:
+ Some markdown.
+*/
+
+let a = 6
+      EOS
+      processed_page_contents = <<-EOS
+/*:
+ Some markdown.
+*/
+let a = 6
+      EOS
+      
+      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+    end
+
+    it 'removes newlines surrounding single-line markdown blocks' do
+      page_contents = <<-EOS
+let a = 6
+
+//: Some markdown.
+
+let b = a
+      EOS
+      processed_page_contents = <<-EOS
+let a = 6
+//: Some markdown.
+let b = a
+      EOS
+      
+      expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
+    end
+  end
+end

--- a/spec/playgroundbook_renderer_spec/page_processor_spec.rb
+++ b/spec/playgroundbook_renderer_spec/page_processor_spec.rb
@@ -56,5 +56,15 @@ let b = a
       
       expect(page_processor.process_page(page_contents)).to eq(processed_page_contents)
     end
+
+    it 'does not strip newlines from code.' do
+      page_contents = <<-EOS
+let a = 6
+
+let b = a
+      EOS
+
+      expect(page_processor.process_page(page_contents)).to eq(page_contents)
+    end
   end
 end

--- a/spec/playgroundbook_renderer_spec/page_writer_spec.rb
+++ b/spec/playgroundbook_renderer_spec/page_writer_spec.rb
@@ -3,12 +3,20 @@ require File.expand_path('../../spec_helper', __FILE__)
 module Playgroundbook
   describe PageWriter do
     include FakeFS::SpecHelpers
-    let(:page_writer) { PageWriter.new(test_ui) }
+    let(:page_writer) { PageWriter.new(page_processor, test_ui) }
+    let(:page_processor) { double(PageProcessor) }
     let(:test_ui) { Cork::Board.new(silent: true) }
     let(:page_name) { 'test page name' }
     let(:page_dir_name) { 'test page name.playgroundpage' }
     let(:page_contents) { "// Some swift goes here." }
     let(:generated_page_contesnts) { "//#-hidden-code\nimport UIKit\n//#-end-hidden-code\n// Some swift goes here." }
+
+    before do
+      allow(page_processor).to receive(:process_page) do |page_contents|
+        # Returns the parameter, unprocessed.
+        page_contents
+      end
+    end
 
     context 'with a pre-existing page directory' do
       before do
@@ -18,6 +26,11 @@ module Playgroundbook
       it 'does not explode' do
         expect{ page_writer.write_page!(page_name, page_dir_name, ['UIKit'],  page_contents) }.to_not raise_error
       end
+    end
+
+    it 'calls the page processor' do
+      expect(page_processor).to receive(:process_page)
+      page_writer.write_page!(page_name, page_dir_name, ['UIKit'],  page_contents)
     end
 
     context 'as a consequence of writing rendering' do

--- a/spec/playgroundbook_renderer_spec/page_writer_spec.rb
+++ b/spec/playgroundbook_renderer_spec/page_writer_spec.rb
@@ -12,7 +12,7 @@ module Playgroundbook
     let(:generated_page_contesnts) { "//#-hidden-code\nimport UIKit\n//#-end-hidden-code\n// Some swift goes here." }
 
     before do
-      allow(page_processor).to receive(:process_page) do |page_contents|
+      allow(page_processor).to receive(:strip_extraneous_newlines) do |page_contents|
         # Returns the parameter, unprocessed.
         page_contents
       end
@@ -29,7 +29,7 @@ module Playgroundbook
     end
 
     it 'calls the page processor' do
-      expect(page_processor).to receive(:process_page)
+      expect(page_processor).to receive(:strip_extraneous_newlines)
       page_writer.write_page!(page_name, page_dir_name, ['UIKit'],  page_contents)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require 'playgroundbook_lint/root_manifest_linter'
 require 'playgroundbook_renderer/contents_manifest_generator'
 require 'playgroundbook_renderer/chapter_collator'
 require 'playgroundbook_renderer/page_writer'
+require 'playgroundbook_renderer/page_processor'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
Fixes #20.

Regexes gave me trouble for stripping lines like 

```
//: Some markdown.


```

I originally used `squeeze("\n")` but that strips consecutive newlines in code, which is not good (I added a test for that). So my solution was to `split` based on a regex that used `\n*` and then `join`. The problem is that this adds a newline before any matched components, so I make sure to remove newlines preceding `//:` comments _after_ that check. Let me know what you think, I'm sure there's a better solution.