### PR TITLE
Embed markdown images inside the created playgrounds

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Current Master
 
 - Support converting a random Markdown file into a playground. See [#29](https://github.com/ashfurrow/playgroundbook/pull/29).
+- Embeds images inside the local Playground when converting from markdown. See [#30](https://github.com/ashfurrow/playgroundbook/pull/30).
+
 
 # 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,54 @@ Sharing resources is only available book-wide and not specific to chapters. Shar
 
 Playground books support a rich set of awesome features to make learning how to code really easy, and this tool uses almost none of them. It sacrifices this experience for the sake of being able to easily write the books on your Mac.
 
+### Creating a Playground from markdown
+
+Maybe you want to do something for a website, or a git repo first, and then generate your Playground? Well in those cases your source of truth is the markdown document. For that case, we have `playgroundbook wrapper`.
+
+For example, you might have a folder that looks like:
+
+``` sh
+$ tree Beginners/Lesson\ One
+
+Beginners/Lesson\ One
+├── README.md
+├── README_ZH.md
+└── img
+    ├── emptyplayground.png
+    ├── multipleresults.png
+    ├── newplayground.png
+    ├── results.png
+    ├── tentimes.png
+    └── welcome.png
+```
+
+You can run:
+```sh
+playgroundbook wrapper "Beginners/Lesson\ One/README.md" "Lesson One"
+```
+
+And it will switch out swift codeblocks into the playground. You _have_ to use  triple backticks with swift <code>```swift</code>. No space between them.
+
+```sh
+$ tree Beginners/Lesson\ One
+
+Beginners/Lesson\ One
+├── Lesson\ One.playground
+│   ├── Contents.swift
+│   ├── Resources
+│   │   └── img
+│   │       ├── emptyplayground.png
+│   │       ├── newplayground.png
+│   │       ├── results.png
+│   │       └── welcome.png
+│   ├── contents.xcplayground
+│   └── timeline.xctimeline
+├── README.md
+...
+```
+
+You might notice that a subset of images, have moved well, they're the only one being used in the `README.md`. Slick huh?
+
 ## License
 
 MIT, except for the `starter.playgroundbook` in the unit tests, which is licensed by Apple.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # playgroundbook
 
-Linter for Swift Playground books based on [Apple's documentation](https://developer.apple.com/library/prerelease/content/documentation/Xcode/Conceptual/swift_playgrounds_doc_format/index.html#//apple_ref/doc/uid/TP40017343-CH47-SW4). It's a work in progress (see [issues](https://github.com/ashfurrow/playground-book-lint/issues)) but you can use it now.
+A series of tools for Swift Playground and Playground books based on [Apple's documentation](https://developer.apple.com/library/prerelease/content/documentation/Xcode/Conceptual/swift_playgrounds_doc_format/index.html#//apple_ref/doc/uid/TP40017343-CH47-SW4). 
+
+It's a work in progress (see [issues](https://github.com/ashfurrow/playground-book-lint/issues)) but you can use it now.
 
 ## Installation
 
@@ -107,7 +109,7 @@ Maybe you want to do something for a website, or a git repo first, and then gene
 For example, you might have a folder that looks like:
 
 ``` sh
-$ tree Beginners/Lesson\ One
+> tree Beginners/Lesson\ One
 
 Beginners/Lesson\ One
 ├── README.md
@@ -129,7 +131,7 @@ playgroundbook wrapper "Beginners/Lesson\ One/README.md" "Lesson One"
 And it will switch out swift codeblocks into the playground. You _have_ to use  triple backticks with swift <code>```swift</code>. No space between them.
 
 ```sh
-$ tree Beginners/Lesson\ One
+> tree Beginners/Lesson\ One
 
 Beginners/Lesson\ One
 ├── Lesson\ One.playground

--- a/lib/wrapper/markdown_wrapper.rb
+++ b/lib/wrapper/markdown_wrapper.rb
@@ -1,5 +1,5 @@
 require "fileutils"
-require 'open-uri'
+require "open-uri"
 
 module Playgroundbook
   # Converts a Markdown file into a Swift Playground

--- a/spec/wrapper/markdown_wrapper_spec.rb
+++ b/spec/wrapper/markdown_wrapper_spec.rb
@@ -68,6 +68,14 @@ module Playgroundbook
         remote_image = "http://ortastuff.s3.amazonaws.com/site/images/twitter_black.png"
         subject.playground_contents.gsub!("img/welcome.png", remote_image)
 
+        # Quacks like the value of `open`
+        class EmptyOpen
+          def read
+            ""
+          end
+        end
+
+        allow(subject).to receive(:open).and_return(EmptyOpen.new)
         subject.generate
 
         source_path = File.join(dir, "Swift at Artsy.playground", "Contents.swift")

--- a/spec/wrapper/markdown_wrapper_spec.rb
+++ b/spec/wrapper/markdown_wrapper_spec.rb
@@ -2,7 +2,6 @@ require File.expand_path("../../spec_helper", __FILE__)
 
 module Playgroundbook
   describe MarkdownWrapper do
-    let(:test_ui) { Cork::Board.new(silent: true) }
 
     it "creates a swift file from a markdown file" do
       source = "spec/fixtures/wrapper/source/swift_at_artsy_1.md"
@@ -27,6 +26,56 @@ module Playgroundbook
         expect(File.exist?(File.join(playground, "Contents.swift"))).to eq(true)
         expect(File.exist?(File.join(playground, "timeline.xctimeline"))).to eq(true)
         expect(File.exist?(File.join(playground, "contents.xcplayground"))).to eq(true)
+      end
+    end
+
+    it "gets the image files inside the markdown doc" do
+      source = "spec/fixtures/wrapper/source/swift_at_artsy_1.md"
+      subject = MarkdownWrapper.new(source, "Swift at Artsy")
+      expect(subject.get_list_of_images(subject.playground_contents)).to eq(
+        ["img/welcome.png", "img/newplayground.png", "img/emptyplayground.png", "img/results.png"]
+      )
+    end
+
+    it "embeds the local images inside the resources folder" do
+      source = "spec/fixtures/wrapper/source/swift_at_artsy_1.md"
+
+      Dir.mktmpdir do |dir|
+        new_source = File.join(dir, File.basename(source))
+        FileUtils.cp(source, new_source)
+
+        # images need to be in the tmpdir relative for picking up
+        Dir.mkdir(File.join(dir, "img"))
+        FileUtils.cp(source, File.join(dir, "img", "welcome.png"))
+
+        subject = MarkdownWrapper.new(new_source, "Swift at Artsy")
+        subject.generate
+
+        embedded_img = File.join(dir, "Swift at Artsy.playground", "Resources", "img/welcome.png")
+        expect(File.exist?(embedded_img)).to eq(true)
+      end
+    end
+
+    it "embeds remote images inside the resources folder, and changes the MD content to match relative url" do
+      source = "spec/fixtures/wrapper/source/swift_at_artsy_1.md"
+
+      Dir.mktmpdir do |dir|
+        new_source = File.join(dir, File.basename(source))
+        FileUtils.cp(source, new_source)
+
+        subject = MarkdownWrapper.new(new_source, "Swift at Artsy")
+        # Switch out a relative link to a remote one
+        remote_image = "http://ortastuff.s3.amazonaws.com/site/images/twitter_black.png"
+        subject.playground_contents.gsub!("img/welcome.png", remote_image)
+
+        subject.generate
+
+        source_path = File.join(dir, "Swift at Artsy.playground", "Contents.swift")
+        expect(File.read(source_path)).to include("twitter_black.png")
+        expect(File.read(source_path)).to_not include(remote_image)
+
+        embedded_img = File.join(dir, "Swift at Artsy.playground", "Resources", "twitter_black.png")
+        expect(File.exist?(embedded_img)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Ain't gonna get far without images. Will download and embed if they're externally referenced, otherwise will keep the same relative paths inside the folder structure of the playground.