### PR TITLE
Don’t default to edge to edge live views

### DIFF
--- a/lib/renderer/page_writer.rb
+++ b/lib/renderer/page_writer.rb
@@ -25,6 +25,7 @@ module Playgroundbook
           file.write({
             "Name" => page_name,
             "LiveViewMode" => "HiddenByDefault",
+            "LiveViewEdgeToEdge" => false,
             "Version" => "1.0",
             "ContentVersion" => "1.0"
           }.to_plist)


### PR DESCRIPTION
I encountered a bug which led to the live view being scaled up quite a bit.

__Before change:__

![img_0411](https://cloud.githubusercontent.com/assets/759730/18608978/4f9710c0-7cf7-11e6-95a1-6bcb760e879e.PNG)

__After change:__

![img_0410](https://cloud.githubusercontent.com/assets/759730/18608986/588794c0-7cf7-11e6-9d35-d8ed79ee74b2.PNG)

Ideally this would be customisable in the `book.yaml` but I wasn't sure on how to achieve this as the chapters are currently `[String]` and should become `[String: String]`:

__Before:__

```yaml
chapters:
  - "Chapter 1"
  - "Chapter 2"
```

__After:___

```yaml
chapters:
  - name: "Chapter 1"
     EdgeToEdgeLiveView: true
  - name: "Chapter 2"
     EdgeToEdgeLiveView: false
```